### PR TITLE
Revert "Bump numpy from 1.26.4 to 2.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ murmurhash==1.0.10
 networkx==3.3
 nh3==0.2.17
 nltk==3.8.1
-numpy==2.0.0
+numpy==1.26.4
 openpyxl==3.1.4
 packaging==24.1
 pandas==2.2.2


### PR DESCRIPTION
Reverts jblake1965/eluciDoc#251