### PR TITLE
Revert "Bump numpy from 1.26.4 to 2.1.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ mpmath==1.3.0
 murmurhash==1.0.10
 networkx==3.3
 nh3==0.2.18
-numpy==2.1.0
+numpy==1.26.4
 openpyxl==3.1.5
 packaging==24.1
 pandas==2.2.2


### PR DESCRIPTION
Reverts jblake1965/eluciDoc#322