### PR TITLE
Revert "Bump spacy from 3.7.6 to 3.8.0"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 keywords = ["legal", "text", "analysis"]
 dependencies = [
     "docx2python==3.0.0", "openpyxl==3.1.5", "pandas==2.2.2", "pdfminer.six==20240706", "python-docx==1.1.2",
-    "rich==13.8.1", "spacy==3.8.0", "textacy==0.13.0"
+    "rich==13.8.1", "spacy==3.7.6", "textacy==0.13.0"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ scipy==1.14.1
 shellingham==1.5.4
 six==1.16.0
 smart-open==7.0.4
-spacy==3.8.0
+spacy==3.7.6
 spacy-alignments==0.9.1
 spacy-legacy==3.0.12
 spacy-loggers==1.0.5


### PR DESCRIPTION
Reverts jblake1965/eluciDoc#363

following error occurs: ModuleNotFoundError: No module named 'thinc.backends.linalg'